### PR TITLE
Pending Intent change 

### DIFF
--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -217,8 +217,14 @@ public final class Notification {
             if (!date.after(new Date()) && trigger(intent, receiver))
                 continue;
 
-            PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, FLAG_CANCEL_CURRENT);
+            PendingIntent pi = null;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                    pi = PendingIntent.getBroadcast(
+                        context, 0, intent, PendingIntent.FLAG_MUTABLE | FLAG_CANCEL_CURRENT);
+            } else {
+                    pi = PendingIntent.getBroadcast(
+                        context, 0, intent, FLAG_CANCEL_CURRENT);
+            }
 
             try {
                 switch (options.getPrio()) {
@@ -304,8 +310,14 @@ public final class Notification {
         for (String action : actions) {
             Intent intent = new Intent(action);
 
-            PendingIntent pi = PendingIntent.getBroadcast(
+            PendingIntent pi = null;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                pi = PendingIntent.getBroadcast(
+                    context, 0, intent, PendingIntent.FLAG_MUTABLE  );
+            } else {
+                pi = PendingIntent.getBroadcast(
                     context, 0, intent, 0);
+            }
 
             if (pi != null) {
                 getAlarmMgr().cancel(pi);


### PR DESCRIPTION
While working on Android 12 ticket, we found that we will require work on  “cordova-plugin-local-notifications” plugin. 

As soon as we jumped our target to 31 and I logon the app, our app crashes with the exception :
```
 java.lang.IllegalArgumentException: com.hrs.patient: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
  Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
    at android.app.PendingIntent.checkFlags(PendingIntent.java:382)
    at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:673)
    at android.app.PendingIntent.getBroadcast(PendingIntent.java:660)
    at de.appplant.cordova.plugin.notification.Notification.schedule(Notification.java:220)
    at de.appplant.cordova.plugin.notification.Manager.schedule(Manager.java:102)
    at de.appplant.cordova.plugin.localnotification.LocalNotification.schedule(LocalNotification.java:270)
    at de.appplant.cordova.plugin.localnotification.LocalNotification.access$400(LocalNotification.java:62)
    at de.appplant.cordova.plugin.localnotification.LocalNotification$1.run(LocalNotification.java:145)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:920)
```
There is an issue which is open for the plugin
https  ://github.com/katzer/cordova-plugin-local-notifications/issues/ 1970

But to keep the app working, we have applied the pendingIntent related check for Android S. 
