### PR TITLE
DEV-16616 Added logs for local notifications plugin

### DIFF
--- a/src/android/ClearReceiver.java
+++ b/src/android/ClearReceiver.java
@@ -25,6 +25,7 @@ import android.os.Bundle;
 
 import de.appplant.cordova.plugin.notification.Notification;
 import de.appplant.cordova.plugin.notification.receiver.AbstractClearReceiver;
+import timber.log.Timber;
 
 import static de.appplant.cordova.plugin.localnotification.LocalNotification.fireEvent;
 import static de.appplant.cordova.plugin.localnotification.LocalNotification.isAppRunning;
@@ -46,7 +47,7 @@ public class ClearReceiver extends AbstractClearReceiver {
     @Override
     public void onClear (Notification notification, Bundle bundle) {
         boolean isLast = bundle.getBoolean(EXTRA_LAST, false);
-
+        Timber.d("LocalNotification: onClear");
         if (isLast) {
             notification.cancel();
         } else {

--- a/src/android/ClearReceiver.java
+++ b/src/android/ClearReceiver.java
@@ -47,7 +47,7 @@ public class ClearReceiver extends AbstractClearReceiver {
     @Override
     public void onClear (Notification notification, Bundle bundle) {
         boolean isLast = bundle.getBoolean(EXTRA_LAST, false);
-        Timber.d("LocalNotification: onClear");
+        Timber.d("onClear Notification id"+ (notification!=null ? notification.getId() : " NA"));
         if (isLast) {
             notification.cancel();
         } else {

--- a/src/android/ClickReceiver.java
+++ b/src/android/ClickReceiver.java
@@ -50,7 +50,7 @@ public class ClickReceiver extends AbstractClickReceiver {
      */
     @Override
     public void onClick(Notification notification, Bundle bundle) {
-        Timber.d("LocalNotification: onClick");
+        Timber.d("onClick Notification id "+ (notification!=null ? notification.getId() : " NA"));
         String action   = getAction();
         JSONObject data = new JSONObject();
 

--- a/src/android/ClickReceiver.java
+++ b/src/android/ClickReceiver.java
@@ -29,6 +29,7 @@ import org.json.JSONObject;
 
 import de.appplant.cordova.plugin.notification.Notification;
 import de.appplant.cordova.plugin.notification.receiver.AbstractClickReceiver;
+import timber.log.Timber;
 
 import static de.appplant.cordova.plugin.localnotification.LocalNotification.fireEvent;
 import static de.appplant.cordova.plugin.notification.Options.EXTRA_LAUNCH;
@@ -49,6 +50,7 @@ public class ClickReceiver extends AbstractClickReceiver {
      */
     @Override
     public void onClick(Notification notification, Bundle bundle) {
+        Timber.d("LocalNotification: onClick");
         String action   = getAction();
         JSONObject data = new JSONObject();
 

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -48,6 +48,7 @@ import de.appplant.cordova.plugin.notification.Notification;
 import de.appplant.cordova.plugin.notification.Options;
 import de.appplant.cordova.plugin.notification.Request;
 import de.appplant.cordova.plugin.notification.action.ActionGroup;
+import timber.log.Timber;
 
 import static de.appplant.cordova.plugin.notification.Notification.Type.SCHEDULED;
 import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERED;
@@ -267,6 +268,7 @@ public class LocalNotification extends CordovaPlugin {
             JSONObject dict    = toasts.optJSONObject(i);
             Options options    = new Options(dict);
             Request request    = new Request(options);
+            Timber.d("Scheduling Local Notification for " + request.toString());
             Notification toast = mgr.schedule(request, TriggerReceiver.class);
 
             if (toast != null) {
@@ -556,6 +558,7 @@ public class LocalNotification extends CordovaPlugin {
 
         js = "cordova.plugins.notification.local.fireEvent(" +
                 "\"" + event + "\"," + params + ")";
+        Timber.d("FireEvent " + js);
 
         if (launchDetails == null && !deviceready && toast != null) {
             launchDetails = new Pair<Integer, String>(toast.getId(), event);
@@ -581,6 +584,7 @@ public class LocalNotification extends CordovaPlugin {
         ((Activity)(view.getContext())).runOnUiThread(new Runnable() {
             public void run() {
                 view.loadUrl("javascript:" + js);
+                Timber.d("Send Javascript : " + js);
             }
         });
     }

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -269,6 +269,7 @@ public class LocalNotification extends CordovaPlugin {
             Options options    = new Options(dict);
             Request request    = new Request(options);
             Notification toast = mgr.schedule(request, TriggerReceiver.class);
+
             Timber.d("Scheduling Local Notification for id " + (toast!=null ? toast.getId() : " NA"));
             if (toast != null) {
                 fireEvent("add", toast);

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -268,9 +268,8 @@ public class LocalNotification extends CordovaPlugin {
             JSONObject dict    = toasts.optJSONObject(i);
             Options options    = new Options(dict);
             Request request    = new Request(options);
-            Timber.d("Scheduling Local Notification for " + request.toString());
             Notification toast = mgr.schedule(request, TriggerReceiver.class);
-
+            Timber.d("Scheduling Local Notification for id " + (toast!=null ? toast.getId() : " NA"));
             if (toast != null) {
                 fireEvent("add", toast);
             }

--- a/src/android/RestoreReceiver.java
+++ b/src/android/RestoreReceiver.java
@@ -50,7 +50,7 @@ public class RestoreReceiver extends AbstractRestoreReceiver {
      */
     @Override
     public void onRestore (Request request, Notification toast) {
-        Timber.d("onRestore: will restore the notifications");
+        Timber.d("onRestore: will restore the notification " + (toast!=null ? toast.getId() : "no notification"));
         Date date     = request.getTriggerDate();
         Timber.d("Restore notification for date " + date);
         boolean after = date != null && date.after(new Date());

--- a/src/android/RestoreReceiver.java
+++ b/src/android/RestoreReceiver.java
@@ -33,6 +33,7 @@ import de.appplant.cordova.plugin.notification.Manager;
 import de.appplant.cordova.plugin.notification.Notification;
 import de.appplant.cordova.plugin.notification.Request;
 import de.appplant.cordova.plugin.notification.receiver.AbstractRestoreReceiver;
+import timber.log.Timber;
 
 /**
  * This class is triggered upon reboot of the device. It needs to re-register
@@ -49,12 +50,16 @@ public class RestoreReceiver extends AbstractRestoreReceiver {
      */
     @Override
     public void onRestore (Request request, Notification toast) {
+        Timber.d("onRestore: will restore the notifications");
         Date date     = request.getTriggerDate();
+        Timber.d("Restore notification for date " + date);
         boolean after = date != null && date.after(new Date());
 
         if (!after && toast.isHighPrio()) {
+            Timber.d("Showing restored notification " + toast.toString());
             toast.show();
         } else {
+            Timber.d("Clearing restored notification " + toast.toString());
             toast.clear();
         }
 

--- a/src/android/TriggerReceiver.java
+++ b/src/android/TriggerReceiver.java
@@ -59,7 +59,7 @@ public class TriggerReceiver extends AbstractTriggerReceiver {
      */
     @Override
     public void onTrigger (Notification notification, Bundle bundle) {
-        Timber.d("OnTrigger " + notification.getId());
+        Timber.d("OnTrigger Notification ID " + (notification!=null ? notification.getId() : " NA"));
         boolean isUpdate = bundle.getBoolean(Notification.EXTRA_UPDATE, false);
         Context context  = notification.getContext();
         Options options  = notification.getOptions();
@@ -75,7 +75,7 @@ public class TriggerReceiver extends AbstractTriggerReceiver {
         }
 
         notification.show();
-        Timber.d("Will Now show Notification : " + notification.toString());
+        Timber.d("Displayed Notification : " + notification.toString());
         if (!isUpdate && isAppRunning()) {
             fireEvent("trigger", notification);
         }

--- a/src/android/TriggerReceiver.java
+++ b/src/android/TriggerReceiver.java
@@ -75,6 +75,7 @@ public class TriggerReceiver extends AbstractTriggerReceiver {
         }
 
         notification.show();
+
         Timber.d("Displayed Notification : " + notification.toString());
         if (!isUpdate && isAppRunning()) {
             fireEvent("trigger", notification);

--- a/src/android/TriggerReceiver.java
+++ b/src/android/TriggerReceiver.java
@@ -33,6 +33,7 @@ import de.appplant.cordova.plugin.notification.Notification;
 import de.appplant.cordova.plugin.notification.Options;
 import de.appplant.cordova.plugin.notification.Request;
 import de.appplant.cordova.plugin.notification.receiver.AbstractTriggerReceiver;
+import timber.log.Timber;
 
 import static android.content.Context.POWER_SERVICE;
 import static android.os.Build.VERSION.SDK_INT;
@@ -58,6 +59,7 @@ public class TriggerReceiver extends AbstractTriggerReceiver {
      */
     @Override
     public void onTrigger (Notification notification, Bundle bundle) {
+        Timber.d("OnTrigger " + notification.getId());
         boolean isUpdate = bundle.getBoolean(Notification.EXTRA_UPDATE, false);
         Context context  = notification.getContext();
         Options options  = notification.getOptions();
@@ -73,7 +75,7 @@ public class TriggerReceiver extends AbstractTriggerReceiver {
         }
 
         notification.show();
-
+        Timber.d("Will Now show Notification : " + notification.toString());
         if (!isUpdate && isAppRunning()) {
             fireEvent("trigger", notification);
         }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -34,7 +34,7 @@ import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.util.ArraySet;
 import android.support.v4.util.Pair;
-import android.util.Log;
+
 import android.util.SparseArray;
 
 import org.json.JSONException;

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -54,7 +54,7 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.support.v4.app.NotificationCompat.PRIORITY_HIGH;
 import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
 import static android.support.v4.app.NotificationCompat.PRIORITY_MIN;
-
+import timber.log.Timber;
 /**
  * Wrapper class around OS notification class. Handles basic operations
  * like show, delete, cancel for a single local notification instance.
@@ -197,7 +197,7 @@ public final class Notification {
             do {
                 Date date = request.getTriggerDate();
 
-                Log.d("local-notification", "Next trigger at: " + date);
+                Timber.d("Local Notification - Scheduled to Next trigger at: " + date);
 
                 if (date == null)
                     continue;
@@ -262,6 +262,8 @@ public final class Notification {
                         // can crash the app
                     }
             }
+        } else {
+            Timber.e("Alarm permission not provided thus wont schedule local notifications");
         }
     }
 


### PR DESCRIPTION
With this MR, we have added logs for various important events for local notifications such as:
- When we are scheduling the notification
- When it is getting rescheduled
- When the notification is fired from the JS side
- When the notification is triggered
- When the notification is shown
- When the notification is clicked
- When the notification is restored
- Used Timber to log the events
- Tested the submitted PCM logs that they show the LocalNotification logs